### PR TITLE
Knapporama

### DIFF
--- a/src/ui/Button/index.js
+++ b/src/ui/Button/index.js
@@ -13,7 +13,14 @@ export const Button = forwardRef(({ className, type, size, spinner, disabled, ch
     ref={ref}
     {...props}
   >
-    {spinner ? <Spinner size='small' /> : children}
+    {
+      spinner &&
+        <div className='button-spinner'><Spinner transparent /></div>
+    }
+
+    <div className={`button-text ${spinner ? 'hide-button-text' : ''}`}>
+      {children}
+    </div>
   </button>
 ))
 

--- a/src/ui/Button/styles.scss
+++ b/src/ui/Button/styles.scss
@@ -4,7 +4,7 @@
 .button {
   @include reset-button();
   display: block;
-  width: 100%;
+  position: relative;
   padding: $baseUnit ($baseUnit * 7);
   border: 1px solid #A3A3A3;
   outline: 0;

--- a/src/ui/Button/styles.scss
+++ b/src/ui/Button/styles.scss
@@ -2,7 +2,6 @@
 @import "../../common/scss/helpers";
 
 .button {
-  @include reset-button();
   display: block;
   position: relative;
   padding: $baseUnit ($baseUnit * 7);

--- a/src/ui/Button/styles.scss
+++ b/src/ui/Button/styles.scss
@@ -3,13 +3,11 @@
 
 .button {
   @include reset-button();
-  outline: 0;
-  font-weight: 700;
-  letter-spacing: 0.4px;
   display: block;
   width: 100%;
   padding: $baseUnit ($baseUnit * 7);
   border: 1px solid #A3A3A3;
+  outline: 0;
 
   transition: width 1s;
   transition: background-color .2s ease-in-out, color .2s ease-in-out;
@@ -93,6 +91,26 @@
     background: #eeeeee;
     border: none;
     cursor: not-allowed;
+  }
+
+  .button-spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    height: 60%;
+    max-height: $baseUnit * 8;
+  }
+
+  .button-text {
+    font-weight: 700;
+    letter-spacing: 0.4px;
+  
+    &.hide-button-text {
+      display: inline-block;
+      visibility: hidden;
+    }
   }
 }
 


### PR DESCRIPTION
- Endret spinner-logikk på knappen til å sette spinnerens høyde til 60% (max 8 * baseUnit), i stedet for at den er hardkodet. Spinneren blir også sentrert i knappen med relativ posisjon.
- I stedet for at teksten i knappen tas vekk skjules den i stedet, slik at størrelsen på knappen ikke "hopper" når spinneren aktiveres. Dvs. at teksten bestemmer størrelsen på knappen, også når spinneren er aktivert. Det gjør også at transition fungerer slik det skal ved disabled state.
- Fjernet reset style på knappen - alt blir satt i komponenten spesifikt eller av normalize.css/BaseStyle.
- Fjernet 100 % width på knapp - dette bør heller settes der komponenten brukes? 
Virker lite logisk å tvinge den til å ha full bredde. Enig, @ksundmyhr?