### PR TITLE
Changed child components to use nanoId as uuid instead of placeholder

### DIFF
--- a/src/ui/Select/index.js
+++ b/src/ui/Select/index.js
@@ -105,7 +105,7 @@ export const Select = ({ placeholder, label, items, selectedItem, id, onChange, 
               onChange={() => onChange(item)}
               onMouseUp={() => handleMouseUp(item)}
               onKeyPress={handleKeyPress}
-              name={`select-${placeholder.replace(/\s+/g, '-').toLowerCase()}`}
+              name={`select-${nanoid()}`}
               value={item.value}
               label={item.label}
               checked={checked}
@@ -149,7 +149,7 @@ export const SelectMultiple = ({ placeholder, label, items, selectedItems, isOpe
             key={index}
             onChange={() => { onChange(item) }}
             onKeyPress={(e) => handleKeyPress(e, item)}
-            name={`select-multiple-${placeholder.replace(/\s+/g, '-').toLowerCase()}`}
+            name={`select-multiple-${nanoid()}`}
             value={item.value}
             label={item.label}
             checked={isSelected(item)}


### PR DESCRIPTION
The reason for this is that "placeholder" is not a required prop for Select.

But if you didn't provide a placeholder the child components would throw.

By using NanoId instead of placeholder as a uuid, placeholder kan stay non-required.