### PR TITLE
Lagt til støtte for å stenge ned Modal ved å trykke på ESC

### DIFF
--- a/src/ui/Modal/index.js
+++ b/src/ui/Modal/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 import ScrollLock, { TouchScrollable } from 'react-scrolllock'
@@ -7,7 +7,16 @@ import { ReactComponent as CloseIcon } from './icon-close.svg'
 
 import './styles.scss'
 
-export function Modal ({ open, title, className, onDismiss, onFinished, ...props }) {
+export function Modal ({ open, title, className, closeOnEscape, onDismiss, onFinished, ...props }) { 
+  // onCreated lifecycle-hook
+  useEffect(() => {
+    function handleKeyPress(e) {
+      if(e?.key === 'Escape' && open && closeOnEscape && onDismiss && typeof onDismiss === 'function') onDismiss();
+    }
+    document.addEventListener('keyup', handleKeyPress)
+    return () => document.removeEventListener('keyup', handleKeyPress)
+  })
+
   return (
     open === true &&
       <>
@@ -60,10 +69,15 @@ export function ModalSideActions (props) {
 Modal.propTypes = {
   children: PropTypes.any,
   className: PropTypes.string,
+  closeOnEscape: PropTypes.bool,
   onDismiss: PropTypes.func.isRequired,
   onFinished: PropTypes.func,
   open: PropTypes.bool.isRequired,
   title: PropTypes.string
+}
+
+Modal.defaultProps = {
+  closeOnEscape: true
 }
 
 ModalBody.propTypes = {


### PR DESCRIPTION
closeOnEscape prop støttes om dette er mulig eller ikke.

closeOnEscape = true som default.
Escape er vanskelig å trykke ved en feiltakelse og det finnes ingen mekanismer i modalen som forcer den åpen. (Som persistent i Dialog)

Så anser dette som noe som bør kunne være på som standard og er en QoL forbedring for brukerne.