### PR TITLE
Iconbutton fixes

### DIFF
--- a/src/ui/Button/Button.stories.js
+++ b/src/ui/Button/Button.stories.js
@@ -47,15 +47,22 @@ const divStyle = { display: 'flex', alignItems: 'flex-start', flexWrap: 'wrap' }
 const buttonStyle = { margin: '5px' }
 
 export function Primary () {
+  const [loading, setLoading] = useState(false)
+
+  const clickHandler = () => {
+    setLoading(true)
+    setTimeout(() => setLoading(false), 3000)
+  }
+
   return (
     <div style={divStyle}>
-      <Button type='primary' size='small' style={buttonStyle}>
+      <Button type='primary' size='small' style={buttonStyle} onClick={clickHandler} spinner={loading}>
         Liten knapp
       </Button>
-      <Button type='primary' style={buttonStyle}>
+      <Button type='primary' style={buttonStyle} onClick={clickHandler} spinner={loading}>
         Medium knapp
       </Button>
-      <Button type='primary' size='large' style={buttonStyle}>
+      <Button type='primary' size='large' style={buttonStyle} onClick={clickHandler} spinner={loading}>
         Stor knapp
       </Button>
     </div>
@@ -63,15 +70,22 @@ export function Primary () {
 }
 
 export function Secondary () {
+  const [loading, setLoading] = useState(false)
+
+  const clickHandler = () => {
+    setLoading(true)
+    setTimeout(() => setLoading(false), 3000)
+  }
+
   return (
     <div style={divStyle}>
-      <Button type='secondary' size='small' style={buttonStyle}>
+      <Button type='secondary' size='small' style={buttonStyle} onClick={clickHandler} spinner={loading}>
         Liten knapp
       </Button>
-      <Button type='secondary' style={buttonStyle}>
+      <Button type='secondary' style={buttonStyle} onClick={clickHandler} spinner={loading}>
         Medium knapp
       </Button>
-      <Button type='secondary' size='large' style={buttonStyle}>
+      <Button type='secondary' size='large' style={buttonStyle} onClick={clickHandler} spinner={loading}>
         Stor knapp
       </Button>
     </div>
@@ -79,15 +93,22 @@ export function Secondary () {
 }
 
 export function Secondary2 () {
+  const [loading, setLoading] = useState(false)
+
+  const clickHandler = () => {
+    setLoading(true)
+    setTimeout(() => setLoading(false), 3000)
+  }
+
   return (
     <div style={divStyle}>
-      <Button type='secondary2' size='small' style={buttonStyle}>
+      <Button type='secondary2' size='small' style={buttonStyle} onClick={clickHandler} spinner={loading}>
         Liten knapp
       </Button>
-      <Button type='secondary2' style={buttonStyle}>
+      <Button type='secondary2' style={buttonStyle} onClick={clickHandler} spinner={loading}>
         Medium knapp
       </Button>
-      <Button type='secondary2' size='large' style={buttonStyle}>
+      <Button type='secondary2' size='large' style={buttonStyle} onClick={clickHandler} spinner={loading}>
         Stor knapp
       </Button>
     </div>

--- a/src/ui/Button/Button.test.js
+++ b/src/ui/Button/Button.test.js
@@ -80,7 +80,7 @@ describe('IconButton', () => {
   })
 
   test('assigning class works and doesn\'t override default classes', async () => {
-    render(<IconButton icon='add' type='transparent-bordered' className='testclass'>Bordered</IconButton>)
+    render(<IconButton icon='add' bordered className='testclass'>Bordered</IconButton>)
     const btn = screen.getByRole('button')
 
     expect(btn).toHaveClass('icon-button')

--- a/src/ui/Button/IconButton.stories.js
+++ b/src/ui/Button/IconButton.stories.js
@@ -44,8 +44,15 @@ export function ShowSpinner () {
 }
 
 export function Bordered () {
+  const [loading, setLoading] = useState(false)
+
+  const clickHandler = () => {
+    setLoading(true)
+    setTimeout(() => setLoading(false), 3000)
+  }
+
   return (
-    <IconButton icon={select('Icon', icons, 'add')} type='transparent-bordered'>
+    <IconButton icon={select('Icon', icons, 'add')} bordered onClick={() => clickHandler()} spinner={loading}>
       {text('Icon Button text', 'Legg til element')}
     </IconButton>
   )

--- a/src/ui/Button/IconButton.stories.js
+++ b/src/ui/Button/IconButton.stories.js
@@ -59,7 +59,14 @@ export function Bordered () {
 }
 
 export function WithoutText () {
+  const [loading, setLoading] = useState(false)
+
+  const clickHandler = (msg) => {
+    setLoading(true)
+    setTimeout(() => setLoading(false), 3000)
+  }
+
   return (
-    <IconButton icon={select('Icon', icons, 'add')} />
+    <IconButton icon={select('Icon', icons, 'add')} onClick={() => clickHandler()} spinner={loading} />
   )
 }

--- a/src/ui/Button/index.js
+++ b/src/ui/Button/index.js
@@ -6,11 +6,12 @@ import { Spinner } from '../Spinner'
 
 import './styles.scss'
 
-export const Button = ({ className, type, size, spinner, disabled, children, ...props }) => {
+export const Button = ({ className, type, size, spinner, disabled, children, onClick, ...props }) => {
   return (
     <button
       className={`button button-${type || 'primary'} button-${size || 'medium'} ${className || ''}`}
       disabled={disabled || spinner || false}
+      onClick={() => onClick && typeof onClick === 'function' && onClick()}
       {...props}
     >
       {
@@ -54,6 +55,7 @@ Button.propTypes = {
   children: PropTypes.string.isRequired,
   className: PropTypes.string,
   disabled: PropTypes.bool,
+  onClick: PropTypes.func,
   size: PropTypes.oneOf([
     'small',
     'medium',

--- a/src/ui/Button/index.js
+++ b/src/ui/Button/index.js
@@ -24,28 +24,30 @@ export const Button = forwardRef(({ className, type, size, spinner, disabled, ch
   </button>
 ))
 
-export const IconButton = forwardRef(({ className, type, icon, spinner, disabled, children, ...props }, ref) => (
-  <button
-    className={`icon-button ${type ? `icon-button-${type}` : ''} ${className || ''}`}
-    disabled={disabled || spinner || false}
-    ref={ref}
-    {...props}
-  >
-    <div className='icon-button-icon'>
+export const IconButton = ({ className, bordered, icon, spinner, disabled, onClick, children, ...props }) => {
+  return (
+    <button
+      className={`icon-button ${bordered ? 'icon-button-transparent-bordered' : ''} ${className || ''}`}
+      disabled={disabled || spinner || false}
+      onClick={() => onClick && typeof onClick === 'function' && onClick()}
+      {...props}
+    >
+      <div className='icon-button-icon'>
+        {
+          spinner
+            ? <Spinner size='small' transparent />
+            : <Icon name={icon || 'add'} size='small' />
+        }
+      </div>
       {
-        spinner
-          ? <Spinner size='small' transparent />
-          : <Icon name={icon || 'add'} size='small' />
+        children &&
+          <div className='icon-button-text'>
+            {children}
+          </div>
       }
-    </div>
-    {
-      children &&
-        <div className='icon-button-text'>
-          {children}
-        </div>
-    }
-  </button>
-))
+    </button>
+  )
+}
 
 Button.propTypes = {
   children: PropTypes.string.isRequired,
@@ -64,15 +66,17 @@ Button.defaultProps = {
 }
 
 IconButton.propTypes = {
+  bordered: PropTypes.bool,
   children: PropTypes.string,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   icon: PropTypes.string.isRequired,
-  spinner: PropTypes.bool,
-  type: PropTypes.string
+  onClick: PropTypes.func,
+  spinner: PropTypes.bool
 }
 
 IconButton.defaultProps = {
+  bordered: false,
   disabled: false,
   spinner: false
 }

--- a/src/ui/Button/index.js
+++ b/src/ui/Button/index.js
@@ -47,8 +47,6 @@ export const IconButton = forwardRef(({ className, type, icon, spinner, disabled
   </button>
 ))
 
-export const IconButtonLink = IconButton
-
 Button.propTypes = {
   children: PropTypes.string.isRequired,
   className: PropTypes.string,

--- a/src/ui/Button/index.js
+++ b/src/ui/Button/index.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 
 import { Icon } from '../Icon'
@@ -6,23 +6,24 @@ import { Spinner } from '../Spinner'
 
 import './styles.scss'
 
-export const Button = forwardRef(({ className, type, size, spinner, disabled, children, ...props }, ref) => (
-  <button
-    className={`button button-${type || 'primary'} button-${size || 'medium'} ${className || ''}`}
-    disabled={disabled || spinner || false}
-    ref={ref}
-    {...props}
-  >
-    {
-      spinner &&
-        <div className='button-spinner'><Spinner transparent /></div>
-    }
+export const Button = ({ className, type, size, spinner, disabled, children, ...props }) => {
+  return (
+    <button
+      className={`button button-${type || 'primary'} button-${size || 'medium'} ${className || ''}`}
+      disabled={disabled || spinner || false}
+      {...props}
+    >
+      {
+        spinner &&
+          <div className='button-spinner'><Spinner transparent /></div>
+      }
 
-    <div className={`button-text ${spinner ? 'hide-button-text' : ''}`}>
-      {children}
-    </div>
-  </button>
-))
+      <div className={`button-text ${spinner ? 'hide-button-text' : ''}`}>
+        {children}
+      </div>
+    </button>
+  )
+}
 
 export const IconButton = ({ className, bordered, icon, spinner, disabled, onClick, children, ...props }) => {
   return (
@@ -53,9 +54,17 @@ Button.propTypes = {
   children: PropTypes.string.isRequired,
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  size: PropTypes.oneOf([
+    'small',
+    'medium',
+    'large'
+  ]),
   spinner: PropTypes.bool,
-  type: PropTypes.oneOf(['primary', 'secondary', 'secondary2'])
+  type: PropTypes.oneOf([
+    'primary',
+    'secondary',
+    'secondary2'
+  ])
 }
 
 Button.defaultProps = {

--- a/src/ui/Button/styles.scss
+++ b/src/ui/Button/styles.scss
@@ -195,6 +195,7 @@
     border-radius: $baseUnit;
     padding: 0 ($baseUnit * 2);
     height: $baseUnit * 5;
+    background-color: white;
 
     .icon-button-icon {
       background: 0;


### PR DESCRIPTION
- Fjernet `IconButtonLink` siden den **kun** var en referanse til `IconButton`. Den ble heller ikke vist frem i noen stories så helt umulig å vite hva den egentlig gjorde uten å se på kildekoden
- Bygd om `IconButton` og `Button` til å **IKKE** bruke `forwardRef` da det ikke er nødvendig her og det forhindrer autocomplete fra å vise frem hvilke props som finnes.
- Propen `type` på **IconButton** er endret til `bordered` som *true*/*false* da den kun godtok en verdi: **transparent-bordered**
- Lagt til `onClick` handlers og `spinners` på **IconButton** og **Button** storiene